### PR TITLE
Added warning for quitting a group

### DIFF
--- a/lib/screens/group_screen.dart
+++ b/lib/screens/group_screen.dart
@@ -12,7 +12,7 @@ class GroupScreen extends StatefulWidget {
   _GroupScreenState createState() => _GroupScreenState();
 }
 
-     bool check = false;
+  bool check = false;
     
 class _GroupScreenState extends State<GroupScreen> {
   final FirebaseFirestore db = FirebaseFirestore.instance;
@@ -179,9 +179,9 @@ void startFetchingMemberLocations() {
               // Add functionality for Messages button here
               Navigator.pushNamed(context, "/itineraryScreen");
             }),
-            // _buildCircularButton(Icons.message, "Messages", Colors.green, () {
-            //   Navigator.pushNamed(context, "/messageScreen");
-            // }),
+            _buildCircularButton(Icons.message, "Messages", Colors.green, () {
+              Navigator.pushNamed(context, "/messageScreen");
+            }),
             _buildCircularButton(Icons.health_and_safety, "Safety", Colors.red, () {
               print("Safety button tapped");
             }),
@@ -208,20 +208,41 @@ void startFetchingMemberLocations() {
               const Color.fromARGB(255, 255, 8, 0),
               () {
                 checkifLeader();
-
                 Future.delayed(const Duration(milliseconds: 500), () {
-                if (check != true) {
-               
-                  user = auth.currentUser!.displayName;
-                  quitGroup(user!);
-                } else {
-                 
-                  userReset(groupcode!);
-                }
-                });
-                
-                Future.delayed(const Duration(milliseconds: 3000), () {
-                  Navigator.pushNamed(context, "/home");
+                  showDialog<String>(
+                    context: context,
+                    builder: (BuildContext context) => AlertDialog(
+                      title: const Text('Quitting?'),
+                      content: Text(
+                        check ?
+                        'If you quit, the entire group will be deleted! Are you sure you want to quit?'
+                        :
+                        'If you quit, you will no longer participate in this group! Are you sure you want to quit?'
+                      ),
+                      actions: <Widget>[
+                        TextButton(
+                          onPressed: () => Navigator.pop(context),
+                          child: const Text('Cancel'),
+                        ),
+                        TextButton(
+                          onPressed: () {
+                            if (check) {
+                              userReset(groupcode!);
+                            } else {
+                              user = auth.currentUser!.displayName;
+                              quitGroup(user!);
+                            }
+                            Future.delayed(
+                              const Duration(milliseconds: 3000), () {
+                                Navigator.pushNamed(context, "/home");
+                              }
+                            );
+                          },
+                          child: const Text('OK'),
+                        ),
+                      ],
+                    ),
+                  );
                 });
               },
             )

--- a/lib/screens/itinerary_screen.dart
+++ b/lib/screens/itinerary_screen.dart
@@ -111,6 +111,10 @@ class ItineraryScreen extends StatelessWidget {
                                 ],
                               ),
                             ),
+                            trailing: const Icon(
+                              Icons.cancel,
+                              color: Colors.red
+                            ),
                           );
                         },
                       );


### PR DESCRIPTION
## Overview

<!-- Denote the type of change being made. Select all that apply. -->
**Type of Change**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] UI change/fix (doesn't break core functionality that changes how app looks)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes  

<!-- Describe the change that is being made. -->
**Proposed Changes**  
*What is the current behavior?*
Quitting a group is instantly done when the QUIT GROUP button is pressed. However, this behavior could result in users leaving or deleting a group either accidentally or prematurely.

*What is the new behavior?*
When the QUIT GROUP button is pressed, a warning message pops-up that reaffirms users if they want to quit the group. The messages varies depending if the user is a Chaperone member or not. If the OK button is pressed, the user either leaves or deletes a group.

The new warning prevents accidental departures or deletions of groups from occurring. It also allows users to have a second chance if they want to leave or delete their group.

**Screenshots**  
![quit_warning](https://github.com/JorgePaz02/Chaperone-SeniorProject/assets/109324288/88022e0c-ed56-4f74-bd47-1e85f7125eea)

<!-- Before opening the PR ensure that you can check off all of these boxes. -->
## Self-Review  Checklist 
- [x] I have added unit and/or integration tests to cover my changes, or my changes did not require additional tests
- [x] All new and existing tests passed on my local machine.
- [x] I did not add unnecessary comments to the code
- [x] I did not add unnecessary logging or debugging code (print statements, for example).
- [x] Errors are properly handled for code that is risky.
- [x] Naming of methods, variables, and classes is proper.
- [x] I wrote a description of requested changes.
- [x] I performed a self-review of my own code.