### PR TITLE
Updated announcements screen

### DIFF
--- a/lib/UserInfo/groupmodel.dart
+++ b/lib/UserInfo/groupmodel.dart
@@ -4,7 +4,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 Future<void> groupSetup(String groupname, int num, String passcode, displayName, int radius) async {
   final db = FirebaseFirestore.instance;
   CollectionReference group = db.collection('Groups');
-  var announcements = ["Welcome, "+groupname];
+  var announcements = [];
   var itinerary = [];
 
   final data = <String, dynamic>{

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,7 +37,7 @@ class MyApp extends StatelessWidget {
           '/Registration': (context) => const Registration(),
           '/joinGroup':(context) => JoinGroupScreen(), 
           '/groupScreen': (context) =>  GroupScreen(), 
-          '/announceScreen': (context) => const AnnouncementScreen(),
+          '/announceScreen': (context) => AnnouncementScreen(),
           "/messageScreen": (context) => const MessageScreen(),
           "/itineraryScreen": (context) => const ItineraryScreen(),       
           "/membersScreen": (context) => const MembersScreen(),       


### PR DESCRIPTION
## Overview

<!-- Denote the type of change being made. Select all that apply. -->
**Type of Change**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] UI change/fix (doesn't break core functionality that changes how app looks)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes  

<!-- Describe the change that is being made. -->
**Proposed Changes**  
*What is the current behavior?*
To create a new announcement, group leaders had to move to a new screen. While the screen itself worked, the act of moving to a whole new screen just to create an announcement was unusual. The action could be made more quicker.

*What is the new behavior?*
Clicking the button now directs the user to a pop-up on the same screen instead of a new screen. Functionally, the pop-up functions identically to the old screen. Additionally, submitting a new announcement now refreshes the screen, allowing groups to immediately see the new announcement.

I also changed the announcements field. Instead of an array of strings, it is now an array of maps. The map contains two variables: _announcement_ and _date_time_. _announcement_ is the announcement itself and _date_time_ is the time and date that the announcement was submitted to the group. Both variables will now be presented for each announcement on the screen.

*If this PR introduces a breaking change, what changes might users need to make in their application due to this PR?* 
With the change to the announcements field, all preexisting groups will now likely break upon viewing the announcements screen until their field are updated to the new version.

I also had to do away with the welcome announcement for now.

<!-- If the UI has changed, you are required to show the before and after. If the UI has not been changed, delete this section. -->
**Screenshots**  
*Before*
[
![annoucementcreatescreen](https://github.com/JorgePaz02/Chaperone-SeniorProject/assets/109324288/8e5f566d-dc0b-40f1-bd50-536f946c9b7e)
](url)

*After*
![announcementcreatedialog](https://github.com/JorgePaz02/Chaperone-SeniorProject/assets/109324288/e30ad98b-6c30-4483-a22f-0a4a4ee759f9)

<!-- Before opening the PR ensure that you can check off all of these boxes. -->
## Self-Review  Checklist 
- [x] I have added unit and/or integration tests to cover my changes, or my changes did not require additional tests
- [x] All new and existing tests passed on my local machine.
- [x] I did not add unnecessary comments to the code
- [x] I did not add unnecessary logging or debugging code (print statements, for example).
- [x] Errors are properly handled for code that is risky.
- [x] Naming of methods, variables, and classes is proper.
- [x] I wrote a description of requested changes.
- [x] I performed a self-review of my own code.